### PR TITLE
fix: ignoring dangling images from image list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Start the program with `gmd`.
 Just build like any other Go binary: 
 
 ```
-go install github.com/ajayd-san/gomanagedocker@v1.3
+go install github.com/ajayd-san/gomanagedocker@3264acc
 ```
 
-Start the program with `gmd`.
+Start the program with `gomanagedocker` (You'll have to rename it to `gmd` if you want, the binary will be installed at your `$GOPATH`).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Start the program with `gmd`.
 Just build like any other Go binary: 
 
 ```
-go install github.com/ajayd-san/gomanagedocker@3264acc
+go install github.com/ajayd-san/gomanagedocker@HEAD
 ```
 
 Start the program with `gomanagedocker` (You'll have to rename it to `gmd` if you want, the binary will be installed at your `$GOPATH`).

--- a/tui/infoCardWrapper.go
+++ b/tui/infoCardWrapper.go
@@ -4,9 +4,10 @@ package tui
 import (
 	"fmt"
 
-	"github.com/ajayd-san/gomanagedocker/dockercmd"
 	teadialog "github.com/ajayd-san/teaDialog"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ajayd-san/gomanagedocker/dockercmd"
 )
 
 const customLoadingMessage = "Loading (this may take some time)..."
@@ -34,7 +35,7 @@ func (m InfoCardWrapperModel) Init() tea.Cmd {
 
 func (m InfoCardWrapperModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd2 tea.Cmd
-	if m.loaded == false {
+	if !m.loaded {
 		spinner, cmd := m.spinner.Update(msg)
 		m.spinner = spinner.(SpinnerModel)
 		m.inner.Message = fmt.Sprintf("%s %s", m.spinner.View(), customLoadingMessage)

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ajayd-san/gomanagedocker/dockercmd"
 	teadialog "github.com/ajayd-san/teaDialog"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -21,15 +20,21 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"golang.design/x/clipboard"
+
+	"github.com/ajayd-san/gomanagedocker/dockercmd"
 )
 
 // dimension ratios for infobox
 const infoBoxWidthRatio = 0.55
+
 const infoBoxHeightRatio = 0.65
 
 type tabId int
+
 type TickMsg time.Time
+
 type preloadObjects int
+
 type preloadSizeMap struct{}
 
 type ContainerSize struct {
@@ -81,6 +86,10 @@ func (m MainModel) Init() tea.Cmd {
 	}
 	// initialize clipboard
 	err = clipboard.Init()
+	if err != nil {
+		fmt.Printf("Failed initalising the clipboard. \nInfo: %s\n", err.Error())
+		os.Exit(1)
+	}
 	// this command enables loading tab contents a head of time, so there is no load time while switching tabs
 	preloadCmd := func() tea.Msg { return preloadObjects(0) }
 	return tea.Batch(preloadCmd, doUpdateObjectsTick())

--- a/tui/types.go
+++ b/tui/types.go
@@ -231,6 +231,10 @@ func makeDescriptionString(str1, str2 string, offset int) string {
 // This function takes in names associated with objects (e.g: RepoTags in case of Image)
 // and concatenates into a string depending on the width of the list
 func transformListNames(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+
 	runningLength := 0
 	var maxindex int
 	for index, name := range names {
@@ -238,7 +242,7 @@ func transformListNames(names []string) string {
 		if runningLength > listContainer.GetWidth()-7 {
 			break
 		}
-		if !(index == len(names)-1) {
+		if index != len(names)-1 {
 			runningLength += 2 // +2 cuz we also append ", " after each element
 		}
 		maxindex = index

--- a/tui/types.go
+++ b/tui/types.go
@@ -49,10 +49,14 @@ type imageItem struct {
 }
 
 func makeImageItems(dockerlist []image.Summary) []dockerRes {
-	res := make([]dockerRes, len(dockerlist))
+	res := make([]dockerRes, 0)
 
 	for i := range dockerlist {
-		res[i] = imageItem{Summary: dockerlist[i]}
+		if len(dockerlist[i].RepoTags) == 0 {
+			continue
+		}
+
+		res = append(res, imageItem{Summary: dockerlist[i]})
 	}
 
 	return res
@@ -140,6 +144,7 @@ func (c containerItem) getState() string {
 
 // INFO: impl list.Item Interface
 func (i containerItem) Title() string { return i.getName() }
+
 func (i containerItem) Description() string {
 
 	id := i.getId()
@@ -193,7 +198,8 @@ func (v VolumeItem) getSize() float64 {
 	return float64(v.UsageData.Size)
 }
 
-func (i VolumeItem) Title() string       { return i.getName() }
+func (i VolumeItem) Title() string { return i.getName() }
+
 func (i VolumeItem) Description() string { return "" }
 
 func makeVolumeItem(dockerlist []*volume.Volume) []dockerRes {

--- a/tui/types_test.go
+++ b/tui/types_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types/image"
 	"gotest.tools/v3/assert"
 )
 
@@ -15,6 +16,31 @@ func TestMakeDescriptionString(t *testing.T) {
 	want := str1 + strings.Repeat(" ", listContainerWidth-len(str1)-len(str2)-3) + str2
 
 	assert.Equal(t, got, want)
+}
+
+func TestMakeImageItems(t *testing.T) {
+	dockerList := []image.Summary{
+		{
+			ID:       "#1",
+			RepoTags: []string{"latest", "tag1", "tag2"},
+		}, {
+			ID:       "#2",
+			RepoTags: []string{},
+		},
+	}
+
+	t.Run("Should only return non dangling items", func(t *testing.T) {
+		// for dangling items the repo tags would be an empty slice
+		got := makeImageItems(dockerList)
+		assert.Equal(t, len(got), 1)
+
+		for _, item := range got {
+			imgItem, ok := item.(imageItem)
+			assert.Equal(t, ok, true)
+			assert.Assert(t, len(imgItem.RepoTags) != 0)
+		}
+	})
+
 }
 
 func TestTransformListNames(t *testing.T) {


### PR DESCRIPTION
[FIX] App panics on startup

When one or more dangling images where found, the app crashed on startup because [here](https://github.com/ajayd-san/gomanagedocker/blob/7d0138e1c9d5f7b0eb919d24ec95d069b209f45b/tui/types.go#L241) trying to access out of bounds object from an empty array

Solved it by only considering non-dangling images as part of image list, such that there would be atleast one valid tag on the image

fixes #18 