### PR TITLE
Remove debug log statements from mainModel.go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## Contributing Guidelines
+
+Hey 👋, thanks for your interest in contributing to goManageDocker. 
+
+You can contribute in 3 ways: 
+
+1. **Report a Bug:** goManageDocker is still new and quite a few bugs might be snooping around! If you find a bug, you can [open an issue](https://github.com/ajayd-san/gomanagedocker/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=BUG+%F0%9F%90%9E%3A) and report the bug, try to be as descriptive about the bug as possible, it genuinely helps.
+2. **Request a feature:** Do you have an idea for a feature that could be a great addition to goManageDocker's blazing-fast (🦀) arsenal? [Open a feature request!](https://github.com/ajayd-san/gomanagedocker/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=)
+3. **Work on a feature/issue:** Do you want to pick up a feature/issue? Then keep reading!
+
+## Setting up the development environment: 
+
+### Requirements: 
+- Go 1.22.2
+- Docker (not really needed, but helpful to debug and final testing)
+
+### Setting up the Development environment
+1. Fork this repository
+2. Clone the forked repo to your local machine
+3. Hack away!
+
+### Debugging 
+I've added a debug flag `--debug` that writes logs to `./gmd_debug.log`. It is helpful while debugging the TUI quickly (for instance, making sure the control flow works as intended) without running a whole debugger (delve), to write a log just put `log.Println({LOG})` where you find fit. 
+
+Make sure to run using `go run main.go --debug` to enable logging. 
+
+### Create a PR. 
+You have now made your changes, congrats! Open a PR and try to be as descriptive as possible, include pertinent information such as a detailed description, issue ID (if it fixes an issue), etc. Adding a test case (if applicable) will reinforce confidence and make the PR move faster.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Introducing **goManageDocker** (get it?)! This blazing fast TUI, made using Go a
 3. [Configuration](#configuration)
 4. [Roadmap](#roadmap)
 5. [Found an issue?](#found-an-issue-)
+6. [Contributing](#contributing)
 
 ## Install Instructions
 
@@ -113,5 +114,11 @@ config:
 ## Found an issue ?
 
 Feel free to open a new issue, I will take a look ASAP.
+
+## Contributing
+
+Please refer [CONTRIBUTING.md](./CONTRIBUTING.md) for more info. 
+
+## Thanks!!
 
 ![image](https://github.com/ajayd-san/gomanagedocker/assets/54715852/61be1ce3-c176-4392-820d-d0e94650ef01)

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -340,7 +339,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.dockerClient.ToggleContainerListAll()
 
 				case key.Matches(msg, ContainerKeymap.ToggleStartStop):
-					log.Println("s pressed")
 					curItem := m.getSelectedItem()
 					if curItem != nil {
 						containerId := curItem.(dockerRes).getId()
@@ -367,7 +365,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case key.Matches(msg, ContainerKeymap.Restart):
 					curItem := m.getSelectedItem()
 					if curItem != nil {
-						log.Println("in restart")
 						containerId := curItem.(dockerRes).getId()
 						err := m.dockerClient.RestartContainer(containerId)
 
@@ -453,7 +450,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else if m.activeTab == VOLUMES {
 				switch {
 				case key.Matches(msg, VolumeKeymap.Prune):
-					log.Println("Volume prune called")
 					curItem := m.getSelectedItem()
 					if curItem != nil {
 						volumeId := curItem.(dockerRes).getId()
@@ -463,7 +459,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 
 				case key.Matches(msg, VolumeKeymap.Delete):
-					log.Println("volume delete called")
 
 					curItem := m.getSelectedItem()
 
@@ -492,7 +487,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		dialogRes := msg
 		switch dialogRes.Kind {
 		case dialogRemoveContainer:
-			log.Println("remove container instruction received")
 			userChoice := dialogRes.UserChoices
 
 			opts := container.RemoveOptions{
@@ -503,9 +497,7 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			containerId := dialogRes.UserStorage["ID"]
 			if containerId != "" {
-				log.Println("removing container: ", dialogRes.UserStorage["ID"])
 				err := m.dockerClient.DeleteContainer(containerId, opts)
-				log.Println("container delete")
 				if err != nil {
 					m.activeDialog = teadialog.NewErrorDialog(err.Error(), m.width)
 					m.showDialog = true
@@ -513,17 +505,12 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case dialogPruneContainers:
-			log.Println("prune containers called")
 			userChoice := dialogRes.UserChoices
 
 			if userChoice["confirm"] == "Yes" {
-				log.Println("prune containers confirmed")
-
 				// prune containers on a separate goroutine, since UI gets stuck otherwise(since this may take sometime)
 				go func() {
-					report, err := m.dockerClient.PruneContainers()
-
-					log.Println(report)
+					_, err := m.dockerClient.PruneContainers()
 
 					if err != nil {
 						m.possibleLongRunningOpErrorChan <- err
@@ -532,17 +519,13 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case dialogPruneImages:
-			log.Println("prune images called")
-
 			userChoice := dialogRes.UserChoices
 
 			if userChoice["confirm"] == "Yes" {
 				// run on a different go routine, same reason as above (for Prune containers)
 				go func() {
-					report, err := m.dockerClient.PruneImages()
-
+					_, err := m.dockerClient.PruneImages()
 					// TODO: show report on screen
-					log.Println("prune images report", report)
 
 					if err != nil {
 						m.possibleLongRunningOpErrorChan <- err
@@ -551,17 +534,12 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case dialogPruneVolumes:
-			log.Println("prune volumes called")
-
 			userChoice := dialogRes.UserChoices
 
 			if userChoice["confirm"] == "Yes" {
 				// same reason as above, again
 				go func() {
-					report, err := m.dockerClient.PruneVolumes()
-
-					log.Println(report)
-
+					_, err := m.dockerClient.PruneVolumes()
 					if err != nil {
 						m.possibleLongRunningOpErrorChan <- err
 					}
@@ -569,7 +547,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case dialogRemoveVolumes:
-			log.Println("remove volume called 2")
 			userChoice := dialogRes.UserChoices
 
 			volumeId := dialogRes.UserStorage["ID"]
@@ -584,7 +561,6 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case dialogRemoveImage:
-			log.Println("remove image instruction received")
 			userChoice := dialogRes.UserChoices
 
 			imageId := dialogRes.UserStorage["ID"]


### PR DESCRIPTION
### Description

This pull request removes unnecessary `log.Println(...)` statements from `mainModel.go` that were initially used for debugging purposes.

### Related Issue

This PR addresses issue #22 

### Changes Made

- Removed `log.Println("s pressed")` from `mainModel.go`.