### PR TITLE
fix: reorder the height and width in WindowTooSmallModel

### DIFF
--- a/tui/windowSizeTooSmallDialog.go
+++ b/tui/windowSizeTooSmallDialog.go
@@ -25,7 +25,12 @@ func (m WindowTooSmallModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m WindowTooSmallModel) View() string {
-	return windowTooSmallStyle.Render(fmt.Sprintf("Window size too small (%d x %d)\n\nConsider going fullscreen for optimal experience.", m.height, m.width))
+	return windowTooSmallStyle.Render(fmt.Sprintf(
+		"Window size too small (%d x %d)\n\n"+
+			"Minimum dimensions needed - Width: 65, Height: 25\n\n"+
+			"Consider going fullscreen for optimal experience.",
+		m.width, m.height,
+	))
 }
 
 func MakeNewWindowTooSmallModel() WindowTooSmallModel {

--- a/tui/windowSizeTooSmallDialog_test.go
+++ b/tui/windowSizeTooSmallDialog_test.go
@@ -1,0 +1,34 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestWindowTooSmallModel_Update(t *testing.T) {
+	model := WindowTooSmallModel{}
+
+	msg := tea.WindowSizeMsg{Width: 100, Height: 24}
+	updatedModel, _ := model.Update(msg)
+
+	if updatedModel.(WindowTooSmallModel).width != 100 {
+		t.Errorf("expected width to be 100, got %d", updatedModel.(WindowTooSmallModel).width)
+	}
+	if updatedModel.(WindowTooSmallModel).height != 24 {
+		t.Errorf("expected height to be 24, got %d", updatedModel.(WindowTooSmallModel).height)
+	}
+}
+
+func TestWindowTooSmallModel_View(t *testing.T) {
+	model := WindowTooSmallModel{width: 100, height: 24}
+	expectedOutput := windowTooSmallStyle.Render(
+		"Window size too small (100 x 24)\n\n" +
+			"Minimum dimensions needed - Width: 65, Height: 25\n\n" +
+			"Consider going fullscreen for optimal experience.",
+	)
+
+	if model.View() != expectedOutput {
+		t.Errorf("expected %q, got %q", expectedOutput, model.View())
+	}
+}


### PR DESCRIPTION
### Description
Change the order of the height and width displayed in WindowTooSmallModel 

<img width="467" alt="image" src="https://github.com/user-attachments/assets/23c29b4e-f420-4bd1-a850-160b51576770">

### Related Issue
#28 

### Changed Made
- Reorder the WindowTooSmallModel Width and Height to display properly
- Added test cases for the WindowTooSmallModel