### PR TITLE
Main model refactoring

### DIFF
--- a/dockercmd/container_test.go
+++ b/dockercmd/container_test.go
@@ -259,10 +259,12 @@ func TestDeleteContainer(t *testing.T) {
 		{
 			ID:    "1",
 			State: "running",
+			Names: []string{"certified loverboy"},
 		},
 		{
 			ID:    "2",
 			State: "stopped",
+			Names: []string{"certified *********"},
 		},
 	}
 

--- a/dockercmd/test_utils.go
+++ b/dockercmd/test_utils.go
@@ -129,9 +129,16 @@ func (mo *MockApi) ContainerRemove(ctx context.Context, container string, option
 		return false
 	})
 
-	if mo.mockContainers[index].State == "running" {
+	if index == -1 {
+		return errors.New(fmt.Sprintf("No such container: %s", container))
+	}
+
+	if mo.mockContainers[index].State == "running" && !options.Force {
 		//not exact error but works for now
-		return errors.New("container is running")
+		return errors.New(fmt.Sprintf(
+			"cannot remove container \"%s\": container is running: stop the container before removing or force remove",
+			mo.mockContainers[index].Names[0],
+		))
 	}
 
 	mo.mockContainers = slices.Delete(mo.mockContainers, index, index+1)

--- a/dockercmd/test_utils.go
+++ b/dockercmd/test_utils.go
@@ -264,6 +264,10 @@ func (m *MockApi) ImageRemove(ctx context.Context, image string, options dimage.
 		return false
 	})
 
+	if index == -1 {
+		return nil, errors.New("No such image:")
+	}
+
 	if !options.Force && m.mockImages[index].Containers > 0 {
 		return nil, errors.New(fmt.Sprintf("unable to delete %s (must be forced) - image is ...", m.mockImages[index].ID))
 	}

--- a/dockercmd/test_utils.go
+++ b/dockercmd/test_utils.go
@@ -87,7 +87,7 @@ func (m *MockApi) ContainerList(ctx context.Context, options container.ListOptio
 	final := []types.Container{}
 
 	for _, cont := range m.mockContainers {
-		if cont.State == "running" || options.All {
+		if cont.State == "running" || cont.State == "paused" || options.All {
 			if !options.Size {
 				cont.SizeRw = -1
 				cont.SizeRootFs = -1

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -362,13 +362,8 @@ notificationLoop:
 
 					if currentItem != nil {
 						dres := currentItem.(dockerRes)
-						id := dres.getId()
-						copyToClipboard(id)
-						timeout_cmd := m.getActiveList().NewStatusMessage(listStatusMessageStyle.Render("ID copied!"))
-						cmds = append(cmds, timeout_cmd)
-
-						// send notification
-						m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render("ID Copied"))
+						op := copyIdToClipboard(dres, m.activeTab, m.notificationChan)
+						op()
 					}
 
 				case key.Matches(msg, ImageKeymap.RunAndExec):
@@ -502,11 +497,10 @@ notificationLoop:
 					currentItem := m.getSelectedItem()
 
 					if currentItem != nil {
-						dres := currentItem.(dockerRes)
-						id := dres.getId()
-						copyToClipboard(id)
+						object := currentItem.(dockerRes)
+						op := copyIdToClipboard(object, m.activeTab, m.notificationChan)
 
-						m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render("Copied ID"))
+						op()
 					}
 				}
 
@@ -537,9 +531,8 @@ notificationLoop:
 
 					if currentItem != nil {
 						dres := currentItem.(dockerRes)
-						name := dres.getId()
-						copyToClipboard(name)
-						m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render("Copied ID"))
+						op := copyIdToClipboard(dres, m.activeTab, m.notificationChan)
+						op()
 					}
 				}
 			}

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -439,16 +439,9 @@ notificationLoop:
 				case key.Matches(msg, ContainerKeymap.Restart):
 					curItem := m.getSelectedItem()
 					if curItem != nil {
-						containerId := curItem.(dockerRes).getId()
-						err := m.dockerClient.RestartContainer(containerId)
-
-						if err != nil {
-							m.activeDialog = teadialog.NewErrorDialog(err.Error(), m.width)
-							m.showDialog = true
-						}
-
-						msg := fmt.Sprintf("Restarted %s", containerId[:8])
-						m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render(msg))
+						containerInfo := curItem.(containerItem)
+						op := toggleRestartContainer(m.dockerClient, containerInfo, m.activeTab, m.notificationChan)
+						m.runBackground(op)
 					}
 
 				case key.Matches(msg, ContainerKeymap.Delete):

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -609,19 +609,11 @@ notificationLoop:
 
 		case dialogRemoveVolumes:
 			userChoice := dialogRes.UserChoices
-
 			volumeId := dialogRes.UserStorage["ID"]
 
 			if volumeId != "" {
-				err := m.dockerClient.DeleteVolume(volumeId, userChoice["force"].(bool))
-
-				if err != nil {
-					m.activeDialog = teadialog.NewErrorDialog(err.Error(), m.width)
-					m.showDialog = true
-					break
-				}
-
-				m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render("Deleted"))
+				op := volumeDelete(m.dockerClient, volumeId, userChoice["force"].(bool), m.activeTab, m.notificationChan)
+				go m.runBackground(op)
 			}
 
 		case dialogRemoveImage:

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -289,23 +289,10 @@ notificationLoop:
 					curItem := m.getSelectedItem()
 
 					if curItem != nil {
-						imageId := curItem.(dockerRes).getId()
+						imageInfo := curItem.(imageItem)
 
-						if imageId != "" {
-							err := m.dockerClient.DeleteImage(imageId, image.RemoveOptions{
-								Force:         true,
-								PruneChildren: false,
-							})
-
-							if err != nil {
-								m.activeDialog = teadialog.NewErrorDialog(err.Error(), m.width)
-								m.showDialog = true
-							}
-							// send notification
-							imageId = strings.TrimPrefix(imageId, "sha256:")
-							msg := fmt.Sprintf("Deleted %s", imageId[:8])
-							m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render(msg))
-						}
+						op := imageDeleteForce(m.dockerClient, imageInfo, m.activeTab, m.notificationChan)
+						go m.runBackground(op)
 					}
 
 				case key.Matches(msg, ImageKeymap.Prune):

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -581,17 +581,7 @@ notificationLoop:
 
 			if userChoice["confirm"] == "Yes" {
 				// same reason as above, again
-				op := func() error {
-					report, err := m.dockerClient.PruneVolumes()
-					if err != nil {
-						return err
-					}
-
-					msg := fmt.Sprintf("Pruned %d volumes", len(report.VolumesDeleted))
-					m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render(msg))
-					return nil
-				}
-
+				op := volumePrune(m.dockerClient, m.activeTab, m.notificationChan)
 				go m.runBackground(op)
 			}
 

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -370,18 +370,7 @@ notificationLoop:
 			} else if m.activeTab == CONTAINERS {
 				switch {
 				case key.Matches(msg, ContainerKeymap.ToggleListAll):
-					m.dockerClient.ToggleContainerListAll()
-
-					listOpts := m.dockerClient.GetListOptions()
-
-					notifMsg := ""
-					if listOpts.All {
-						notifMsg = "List all enabled!"
-					} else {
-						notifMsg = "List all disabled!"
-					}
-
-					m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render(notifMsg))
+					toggleListAllContainers(&m.dockerClient, m.activeTab, m.notificationChan)
 
 				case key.Matches(msg, ContainerKeymap.ToggleStartStop):
 					curItem := m.getSelectedItem()

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -572,19 +572,7 @@ notificationLoop:
 			userChoice := dialogRes.UserChoices
 
 			if userChoice["confirm"] == "Yes" {
-				// run on a different go routine, same reason as above (for Prune containers)
-				op := func() error {
-					report, err := m.dockerClient.PruneImages()
-
-					if err != nil {
-						return err
-					}
-
-					msg := fmt.Sprintf("Pruned %d images", len(report.ImagesDeleted))
-					m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render(msg))
-					return nil
-				}
-
+				op := imagePrune(m.dockerClient, m.activeTab, m.notificationChan)
 				go m.runBackground(op)
 			}
 

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -28,10 +28,6 @@ import (
 	"github.com/ajayd-san/gomanagedocker/tui/components"
 )
 
-func UNUSED(...any) {
-
-}
-
 // dimension ratios for infobox
 const infoBoxWidthRatio = 0.55
 const infoBoxHeightRatio = 0.6
@@ -655,13 +651,17 @@ notificationLoop:
 					and calculate progress bar completion, adding `2/1` will enable the progress bar to show 100% when image
 					is done building
 				*/
-				buildInfoCard.progressChan <- "Step 2/1 : Build Complete!"
+
+				/*
+				 FIX: this doesn't get colored, mostly prolly because buildInfoCard.Update uses regex to split string into groups,
+				 so ANSI color codes are lost
+				*/
+				buildInfoCard.progressChan <- successForeground.Render("Step 2/1 : Build Complete!")
+
+				m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render("Build Complete!"))
 
 				return nil
 			}
-
-			notif := NewNotification(m.activeTab, listStatusMessageStyle.Render("Build Complete!"))
-			UNUSED(notif)
 
 			go m.runBackground(op)
 		}

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -388,7 +388,7 @@ notificationLoop:
 					if curItem != nil {
 						containerInfo := curItem.(containerItem)
 						op := toggleStartStopContainer(m.dockerClient, containerInfo, m.activeTab, m.notificationChan)
-						m.runBackground(op)
+						go m.runBackground(op)
 					}
 
 				case key.Matches(msg, ContainerKeymap.TogglePause):
@@ -396,7 +396,7 @@ notificationLoop:
 					if curItem != nil {
 						containerInfo := curItem.(containerItem)
 						op := togglePauseResumeContainer(m.dockerClient, containerInfo, m.activeTab, m.notificationChan)
-						m.runBackground(op)
+						go m.runBackground(op)
 					}
 
 				case key.Matches(msg, ContainerKeymap.Restart):
@@ -404,7 +404,7 @@ notificationLoop:
 					if curItem != nil {
 						containerInfo := curItem.(containerItem)
 						op := toggleRestartContainer(m.dockerClient, containerInfo, m.activeTab, m.notificationChan)
-						m.runBackground(op)
+						go m.runBackground(op)
 					}
 
 				case key.Matches(msg, ContainerKeymap.Delete):
@@ -428,7 +428,7 @@ notificationLoop:
 
 						op := containerDelete(m.dockerClient, containerId, deleteOpts, m.activeTab, m.notificationChan)
 
-						m.runBackground(op)
+						go m.runBackground(op)
 					}
 
 				case key.Matches(msg, ContainerKeymap.Prune):

--- a/tui/mainModel.go
+++ b/tui/mainModel.go
@@ -455,20 +455,10 @@ notificationLoop:
 
 				case key.Matches(msg, ContainerKeymap.DeleteForce):
 					curItem := m.getSelectedItem()
-					if containerInfo, ok := curItem.(dockerRes); ok {
-						err := m.dockerClient.DeleteContainer(containerInfo.getId(), container.RemoveOptions{
-							RemoveVolumes: false,
-							RemoveLinks:   false,
-							Force:         true,
-						})
-
-						if err != nil {
-							m.activeDialog = teadialog.NewErrorDialog(err.Error(), m.width)
-							m.showDialog = true
-						}
-
-						msg := fmt.Sprintf("Deleted %s", containerInfo.getId()[:8])
-						m.notificationChan <- NewNotification(m.activeTab, listStatusMessageStyle.Render(msg))
+					if curItem != nil {
+						containerInfo := curItem.(containerItem)
+						op := containerDeleteForce(m.dockerClient, containerInfo, m.activeTab, m.notificationChan)
+						m.runBackground(op)
 					}
 
 				case key.Matches(msg, ContainerKeymap.Prune):

--- a/tui/mainModel_test.go
+++ b/tui/mainModel_test.go
@@ -285,19 +285,12 @@ func TestRunBackground(t *testing.T) {
 			return errors.New("error")
 		}
 
-		notif := NewNotification(1, "Test notification")
-		model.runBackground(op, &notif)
+		model.runBackground(op)
 
 		select {
 		case <-model.possibleLongRunningOpErrorChan:
 		default:
 			t.Errorf("Should recieve an error")
-		}
-
-		select {
-		case <-model.notificationChan:
-			t.Errorf("Should not recieve a notification")
-		default:
 		}
 	})
 
@@ -306,19 +299,12 @@ func TestRunBackground(t *testing.T) {
 			return nil
 		}
 
-		notif := NewNotification(1, "Test notification")
-		model.runBackground(op, &notif)
+		model.runBackground(op)
 
 		select {
 		case <-model.possibleLongRunningOpErrorChan:
 			t.Errorf("Should not recieve an error")
 		default:
-		}
-
-		select {
-		case <-model.notificationChan:
-		default:
-			t.Errorf("Should recieve a notification")
 		}
 	})
 }

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -167,3 +167,18 @@ func volumeDelete(client dockercmd.DockerClient, volumeId string, force bool, ac
 		return nil
 	}
 }
+
+func imagePrune(client dockercmd.DockerClient, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+
+		report, err := client.PruneImages()
+
+		if err != nil {
+			return err
+		}
+
+		msg := fmt.Sprintf("Pruned %d images", len(report.ImagesDeleted))
+		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
+		return nil
+	}
+}

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -154,3 +154,16 @@ func imageDelete(client dockercmd.DockerClient, imageId string, opts image.Remov
 		return nil
 	}
 }
+
+func volumeDelete(client dockercmd.DockerClient, volumeId string, force bool, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+		err := client.DeleteVolume(volumeId, force)
+
+		if err != nil {
+			return err
+		}
+
+		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render("Deleted"))
+		return nil
+	}
+}

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -1,0 +1,63 @@
+/*
+	this file contains docker ops, they are put in a seperate file to facilitate easier testing
+*/
+
+package tui
+
+import (
+	"fmt"
+
+	"github.com/ajayd-san/gomanagedocker/dockercmd"
+)
+
+type Operation func() error
+
+// Calls dockercmd api to toggle start/stop container, and sends notification to `notificaitonChan`
+func toggleStartStopContainer(cli dockercmd.DockerClient, containerInfo containerItem, activeTab tabId, notifcationChan chan notificationMetadata) Operation {
+
+	return func() error {
+		containerId := containerInfo.getId()
+		err := cli.ToggleStartStopContainer(containerId)
+
+		if err != nil {
+			return err
+		}
+
+		// send notification
+		msg := ""
+		if containerInfo.getState() == "running" {
+			msg = fmt.Sprintf("Stopped %s", containerId[:8])
+		} else {
+			msg = fmt.Sprintf("Started %s", containerId[:8])
+		}
+
+		notif := NewNotification(activeTab, listStatusMessageStyle.Render(msg))
+
+		notifcationChan <- notif
+		return nil
+	}
+}
+
+// Calls dockercmd api to toggle pause/resume container, and sends notification to `notificaitonChan`
+func togglePauseResumeContainer(client dockercmd.DockerClient, containerInfo containerItem, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+		containerId := containerInfo.getId()
+		err := client.TogglePauseResume(containerId)
+
+		if err != nil {
+			return err
+		}
+
+		// send notification
+		msg := ""
+		if containerInfo.getState() == "running" {
+			msg = "Paused " + containerId[:8]
+		} else {
+			msg = "Resumed " + containerId[:8]
+		}
+
+		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
+
+		return nil
+	}
+}

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -114,3 +114,25 @@ func copyIdToClipboard(object dockerRes, activeTab tabId, notificationChan chan 
 		return nil
 	}
 }
+
+func runImage(client dockercmd.DockerClient, imageInfo imageItem, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+		imageId := imageInfo.getId()
+
+		config := container.Config{
+			Image: imageId,
+		}
+		_, err := client.RunImage(config)
+
+		if err != nil {
+			return err
+		}
+
+		imageId = strings.TrimPrefix(imageId, "sha256:")
+		notificationMsg := listStatusMessageStyle.Render(fmt.Sprintf("Run %s", imageId[:8]))
+
+		notificationChan <- NewNotification(activeTab, notificationMsg)
+
+		return nil
+	}
+}

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -182,3 +182,17 @@ func imagePrune(client dockercmd.DockerClient, activeTab tabId, notificationChan
 		return nil
 	}
 }
+
+func volumePrune(client dockercmd.DockerClient, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+		report, err := client.PruneVolumes()
+		if err != nil {
+			return err
+		}
+
+		msg := fmt.Sprintf("Pruned %d volumes", len(report.VolumesDeleted))
+		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
+		return nil
+
+	}
+}

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -84,20 +84,16 @@ func toggleRestartContainer(client dockercmd.DockerClient, containerInfo contain
 	}
 }
 
-// Returns func that calls dockercmd api to deletes container FORCEFULLY and sends notification to notificationChan
-func containerDeleteForce(client dockercmd.DockerClient, containerInfo containerItem, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+// Returns func that calls dockercmd api to deletes container using `opts` as options and sends notification to notificationChan
+func containerDelete(client dockercmd.DockerClient, containerId string, opts container.RemoveOptions, activeTab tabId, notificationChan chan notificationMetadata) Operation {
 	return func() error {
-		err := client.DeleteContainer(containerInfo.getId(), container.RemoveOptions{
-			RemoveVolumes: false,
-			RemoveLinks:   false,
-			Force:         true,
-		})
+		err := client.DeleteContainer(containerId, opts)
 
 		if err != nil {
 			return err
 		}
 
-		msg := fmt.Sprintf("Deleted %s", containerInfo.getId()[:8])
+		msg := fmt.Sprintf("Deleted %s", containerId[:8])
 		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
 		return nil
 	}
@@ -160,7 +156,5 @@ func imageDeleteForce(client dockercmd.DockerClient, imageInfo imageItem, active
 		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
 
 		return nil
-
 	}
-
 }

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -61,3 +61,20 @@ func togglePauseResumeContainer(client dockercmd.DockerClient, containerInfo con
 		return nil
 	}
 }
+
+// Calls dockercmd api to restart container and sends notification to notificationChan
+func toggleRestartContainer(client dockercmd.DockerClient, containerInfo containerItem, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+		containerId := containerInfo.getId()
+		err := client.RestartContainer(containerId)
+
+		if err != nil {
+			return err
+		}
+
+		msg := fmt.Sprintf("Restarted %s", containerId[:8])
+		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
+
+		return nil
+	}
+}

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -7,8 +7,11 @@ package tui
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/ajayd-san/gomanagedocker/dockercmd"
 	"github.com/docker/docker/api/types/container"
+	"golang.design/x/clipboard"
 )
 
 type Operation func() error
@@ -95,6 +98,19 @@ func containerDeleteForce(client dockercmd.DockerClient, containerInfo container
 
 		msg := fmt.Sprintf("Deleted %s", containerInfo.getId()[:8])
 		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(msg))
+		return nil
+	}
+}
+
+func copyIdToClipboard(object dockerRes, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+	return func() error {
+		id := object.getId()
+		id = strings.TrimPrefix(id, "sha256:")
+		id = id[:min(len(id), 20)]
+		clipboard.Write(clipboard.FmtText, []byte(id))
+
+		notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render("ID copied!"))
+
 		return nil
 	}
 }

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -17,6 +17,21 @@ import (
 
 type Operation func() error
 
+// Hides/shows existed containers and sends notification to `notificationChan`
+func toggleListAllContainers(client *dockercmd.DockerClient, activeTab tabId, notificationChan chan notificationMetadata) {
+	client.ToggleContainerListAll()
+	listOpts := client.GetListOptions()
+
+	notifMsg := ""
+	if listOpts.All {
+		notifMsg = "List all enabled!"
+	} else {
+		notifMsg = "List all disabled!"
+	}
+
+	notificationChan <- NewNotification(activeTab, listStatusMessageStyle.Render(notifMsg))
+}
+
 // Returns func that calls dockercmd api to toggle start/stop container, and sends notification to `notificaitonChan`
 func toggleStartStopContainer(cli dockercmd.DockerClient, containerInfo containerItem, activeTab tabId, notifcationChan chan notificationMetadata) Operation {
 

--- a/tui/operations.go
+++ b/tui/operations.go
@@ -136,14 +136,10 @@ func runImage(client dockercmd.DockerClient, imageInfo imageItem, activeTab tabI
 	}
 }
 
-// Deletes image(FORCE) and sends notification to `notificationChan`
-func imageDeleteForce(client dockercmd.DockerClient, imageInfo imageItem, activeTab tabId, notificationChan chan notificationMetadata) Operation {
+// Deletes image with `opts` and sends notification to `notificationChan`
+func imageDelete(client dockercmd.DockerClient, imageId string, opts image.RemoveOptions, activeTab tabId, notificationChan chan notificationMetadata) Operation {
 	return func() error {
-		imageId := imageInfo.getId()
-		err := client.DeleteImage(imageId, image.RemoveOptions{
-			Force:         true,
-			PruneChildren: false,
-		})
+		err := client.DeleteImage(imageId, opts)
 
 		if err != nil {
 			return err

--- a/tui/operations_test.go
+++ b/tui/operations_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/volume"
 	"golang.design/x/clipboard"
 	"gotest.tools/v3/assert"
 )
@@ -72,8 +73,21 @@ func setupTest(t *testing.T) dockercmd.DockerClient {
 		},
 	}
 
+	vols := []*volume.Volume{
+		{
+			Name: "1",
+		},
+		{
+			Name: "2",
+		},
+		{
+			Name: "3",
+		},
+	}
+
 	api.SetMockContainers(containers)
 	api.SetMockImages(imgs)
+	api.SetMockVolumes(vols)
 
 	mock := dockercmd.NewMockCli(&api)
 	return mock

--- a/tui/operations_test.go
+++ b/tui/operations_test.go
@@ -1,0 +1,232 @@
+package tui
+
+import (
+	"log"
+	"slices"
+	"testing"
+
+	"github.com/ajayd-san/gomanagedocker/dockercmd"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/image"
+	"gotest.tools/v3/assert"
+)
+
+func setupTest(t *testing.T) dockercmd.DockerClient {
+	api := dockercmd.MockApi{}
+
+	containers := []types.Container{
+		{
+			Names:      []string{"a"},
+			ID:         "1aaaaaaaa",
+			SizeRw:     1e+9,
+			SizeRootFs: 2e+9,
+			State:      "running",
+			Status:     "",
+		},
+		{
+			Names:      []string{"b"},
+			ID:         "2aaaaaaaa",
+			SizeRw:     201,
+			SizeRootFs: 401,
+			State:      "running",
+		},
+		{
+			Names:      []string{"c"},
+			ID:         "3aaaaaaaa",
+			SizeRw:     202,
+			SizeRootFs: 402,
+			State:      "running",
+		},
+		{
+			Names:      []string{"d"},
+			ID:         "4aaaaaaaa",
+			SizeRw:     203,
+			SizeRootFs: 403,
+			State:      "running",
+		},
+	}
+
+	imgs := []image.Summary{
+		{
+			Containers: 0,
+			ID:         "0bbbbbbbb",
+			RepoTags:   []string{"a"},
+		},
+
+		{
+			Containers: 0,
+			ID:         "1bbbbbbbb",
+			RepoTags:   []string{"b"},
+		},
+		{
+			Containers: 3,
+			ID:         "2bbbbbbbb",
+			RepoTags:   []string{"c"},
+		},
+		{
+			Containers: 0,
+			ID:         "3bbbbbbbb",
+			RepoTags:   []string{"d"},
+		},
+	}
+
+	api.SetMockContainers(containers)
+	api.SetMockImages(imgs)
+
+	mock := dockercmd.NewMockCli(&api)
+	return mock
+}
+
+func TestToggleStartStopContainer(t *testing.T) {
+
+	tests := []struct {
+		target    types.Container
+		want      string
+		notifWant string
+	}{
+		{
+			target: types.Container{
+				Names:      []string{"b"},
+				ID:         "2aaaaaaaa",
+				SizeRw:     201,
+				SizeRootFs: 401,
+				State:      "running",
+			},
+			want:      "stopped",
+			notifWant: listStatusMessageStyle.Render("Stopped 2aaaaaaa"),
+		},
+		{
+			target: types.Container{
+				Names:      []string{"b"},
+				ID:         "2aaaaaaaa",
+				SizeRw:     201,
+				SizeRootFs: 401,
+				State:      "stopped",
+			},
+			want:      "running",
+			notifWant: listStatusMessageStyle.Render("Started 2aaaaaaa"),
+		},
+	}
+
+	mock := setupTest(t)
+	mock.ToggleContainerListAll()
+
+	for _, testCase := range tests {
+		t.Run("Test for existing container", func(t *testing.T) {
+			target := containerItem{
+				testCase.target,
+			}
+
+			notifChan := make(chan notificationMetadata, 10)
+			op := toggleStartStopContainer(mock, target, 1, notifChan)
+
+			op()
+
+			t.Run("Test Stopping", func(t *testing.T) {
+				containers := mock.ListContainers(false)
+				index := slices.IndexFunc(containers, func(elem types.Container) bool {
+					if elem.ID == target.ID {
+						return true
+					}
+
+					return false
+				})
+
+				got := containers[index]
+
+				assert.Equal(t, got.State, testCase.want)
+			})
+
+			t.Run("Assert Notification", func(t *testing.T) {
+				select {
+				case notif := <-notifChan:
+					assert.Equal(t, notif, notificationMetadata{
+						listId: 1,
+						msg:    testCase.notifWant,
+					})
+				default:
+					t.Errorf("No notification received")
+				}
+			})
+		})
+	}
+}
+
+func TestTogglePauseResumeContainer(t *testing.T) {
+	mock := setupTest(t)
+
+	tests := []struct {
+		target    types.Container
+		want      string
+		notifWant string
+	}{
+		{
+			target: types.Container{
+				Names:      []string{"b"},
+				ID:         "2aaaaaaaa",
+				SizeRw:     201,
+				SizeRootFs: 401,
+				State:      "running",
+			},
+			want:      "paused",
+			notifWant: listStatusMessageStyle.Render("Paused 2aaaaaaa"),
+		},
+		{
+			target: types.Container{
+				Names:      []string{"b"},
+				ID:         "2aaaaaaaa",
+				SizeRw:     201,
+				SizeRootFs: 401,
+				State:      "paused",
+			},
+			want:      "running",
+			notifWant: listStatusMessageStyle.Render("Resumed 2aaaaaaa"),
+		},
+	}
+
+	for _, testCase := range tests {
+
+		t.Run("Test for Existing Container", func(t *testing.T) {
+
+			target := containerItem{
+				testCase.target,
+			}
+
+			notifChan := make(chan notificationMetadata, 10)
+			op := togglePauseResumeContainer(mock, target, 2, notifChan)
+
+			op()
+
+			t.Run("Assert Paused State", func(t *testing.T) {
+				containers := mock.ListContainers(false)
+				log.Println(containers)
+
+				index := slices.IndexFunc(containers, func(elem types.Container) bool {
+					if elem.ID == target.ID {
+						return true
+					}
+
+					return false
+				})
+
+				got := containers[index]
+
+				assert.Equal(t, got.State, testCase.want)
+			})
+
+			t.Run("Assert Notification", func(t *testing.T) {
+				select {
+				case notif := <-notifChan:
+					assert.Equal(t, notif, notificationMetadata{
+						listId: 2,
+						msg:    testCase.notifWant,
+					})
+				default:
+					t.Errorf("No notification received")
+				}
+			})
+
+		})
+
+	}
+}

--- a/tui/operations_test.go
+++ b/tui/operations_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ajayd-san/gomanagedocker/dockercmd"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
+	"golang.design/x/clipboard"
 	"gotest.tools/v3/assert"
 )
 
@@ -305,4 +306,24 @@ func TestContainerDeleteForce(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestCopyIdToClipboard(t *testing.T) {
+	clipboard.Init()
+	target := containerItem{
+		types.Container{
+			Names:      []string{"b"},
+			ID:         "TuTuRuu!",
+			SizeRw:     201,
+			SizeRootFs: 401,
+			State:      "running",
+		},
+	}
+
+	notifChan := make(chan notificationMetadata, 10)
+	op := copyIdToClipboard(target, 1, notifChan)
+	op()
+
+	got := clipboard.Read(clipboard.FmtText)
+	assert.Equal(t, string(got), target.ID)
 }

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -8,6 +8,10 @@ var (
 )
 
 var (
+	successForeground = lipgloss.NewStyle().Foreground(statusGreen)
+)
+
+var (
 	inactiveTabBorder = tabBorderWithBottom("┴", "─", "┴")
 	activeTabBorder   = tabBorderWithBottom("┘", " ", "└")
 	// The outer most container, this just applies padding to the Window


### PR DESCRIPTION
This PR refactors mainModel.go to a much cleaner state. It should be easily navigatable now as before it was a mess and too long. 

All the docker operations now are in `operations.go`, the primary reason for doing this is to facilitate easier testing as are operations are now pure functions and do not need to simulate a bubble tea session to test these 😮‍💨