### PR TITLE
V1.5 remove linux arm64 build steps in ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,11 @@ jobs:
     - name: Build artifact amd64
       run: go build -o gmd_linux_amd64 .
 
-    - name: Build artifact arm64
-      run: env GOOS=linux GOARCH=arm64 go build -o gmd_linux_arm64 .
-
     - name: Store version info
       run: echo "version=v$(./gmd_linux_amd64 -v | cut --delimiter ' ' --fields 3)" >> $GITHUB_ENV
 
     - name: Tar artifact
-      run: |
-        tar czf gomanagedocker_linux_amd64_${version}.tar.gz gmd_linux_amd64
-        tar czf gomanagedocker_linux_arm64_${version}.tar.gz gmd_linux_arm64
+      run: tar czf gomanagedocker_linux_amd64_${version}.tar.gz gmd_linux_amd64
 
     - name: Upload linux assets
       uses: actions/upload-artifact@v4
@@ -95,3 +90,4 @@ jobs:
           files: |
             linux_artifacts/*
             macos_artifacts/*
+

--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ You can install the latest release of goManageDocker on UNIX systems with a simp
 bash -c "$(curl -sLo- https://raw.githubusercontent.com/ajayd-san/gomanagedocker/main/install.sh)"
 ```
 
+This is the recommended way to install on Linux(`amd64` only) and MacOS(both `intel` and `arm`) systems. 
 Start the program with `gmd`. 
+
+### Windows
+
+Building from source is currently the only way to install this on Windows. See next section. 
 
 ### Build from source
 
-Just build like any other Go binary: 
+Just build like any other Go binary, this is currently the only way to make goManageDocker work on Windows and arm64 chipsets running **Linux**: 
 
 ```
 go install github.com/ajayd-san/gomanagedocker@main
@@ -37,26 +42,25 @@ go install github.com/ajayd-san/gomanagedocker@main
 
 Start the program with `gomanagedocker` (Rename it to `gmd` if you'd like, the binary will be installed at your `$GOPATH`).
 
-### Windows
-
-You can get the latest precompiled binary from releases or you may build from source. 
-
-Now, **goManageDocker 😏!!**
-
-> [!NOTE]
-> goManageDocker runs best on terminals that support ANSI 256 colors and designed to run while the **terminal is maximized**.
 
 ### Docker
 Want to try this without installing a binary? I gotchu!
 
-Docker:
+**Docker:**
 
 ```
 docker run -it -v /var/run/docker.sock:/var/run/docker.sock kakshipth/gomanagedocker:latest
 ```
 
-Podman:
+**Podman:**
 
+First start the podman service: 
+
+```
+systemctl --user start podman.socket
+```
+
+And then: 
 ```
 docker run -it -v /run/user/1000/podman/podman.sock:/run/user/1000/podman/podman.sock kakshipth/gomanagedocker:latest p
 ```
@@ -95,11 +99,16 @@ gmd p
 > The command to invoke the TUI changes depending on the install method, if you installed from source you would be typing `gomanagedocker` instead of `gmd` (unless you aliased it to `gmd`).
 
 
+Now, **goManageDocker 😏!!**
+
+> [!NOTE]
+> goManageDocker runs best on terminals that support ANSI 256 colors and designed to run while the **terminal is maximized**.
+
 ## Features
 
 ### **New in v1.5:**
 
-1. goManageDocker now has first class support for Podman!! (who doesn't like more secure containers 😉). You can now manage podman images, container, volumes and even pods from the TUI!
+1. goManageDocker now has first class support for Podman!! (who doesn't like more secure containers 😉). You can now manage podman images, containers, volumes and even pods from the TUI!
 
 	![podmanRun](vhs/gifs/podmanRun.gif)
 
@@ -241,7 +250,7 @@ config:
 ## Roadmap
 
 - Add a networks tab
-- Make compatible with podman 👀
+- ~~Make compatible with podman 👀~~
 
 ## Found an issue ?
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to simplify the build process and updates to the `README.md` to clarify installation instructions and improve documentation.

Changes to build process:

* `.github/workflows/release.yml`: Removed the build and tar steps for the `arm64` architecture, focusing only on the `amd64` architecture.


###Documentation updates:

readme.md: 

1. Added a note recommending the installation method for Linux (`amd64` only) and MacOS (both `intel` and `arm`). Also, clarified that building from source is currently the only way to install on Windows and `arm64` Linux systems.
2. Reintroduced the section on using goManageDocker, emphasizing the best terminal support for the application.
3.  Updated the roadmap to mark the compatibility with Podman as completed.